### PR TITLE
Marshal.SizeOf(Type) throws an ERROR.

### DIFF
--- a/tests/baseobjecttest.py
+++ b/tests/baseobjecttest.py
@@ -482,7 +482,7 @@ class PyBaseObject_Type_Test(TypeTestCase):
         
         baseObjTypeBlock = mapper.PyBaseObject_Type
         objTypeBlock = mapper.PyDict_Type # type not actually important
-        objPtr = Marshal.AllocHGlobal(Marshal.SizeOf(PyObject))
+        objPtr = Marshal.AllocHGlobal(Marshal.SizeOf(PyObject()))
         addToCleanUp(lambda: Marshal.FreeHGlobal(objPtr))
 
         CPyMarshal.WriteFunctionPtrField(objTypeBlock, PyTypeObject, "tp_free", self.freeDgt)
@@ -500,7 +500,7 @@ class NewInitFunctionsTest(TestCase):
         typePtr, deallocType = MakeTypePtr(mapper, {'tp_name': 'FooType'})
         addToCleanUp(deallocType)
 
-        objPtr = Marshal.AllocHGlobal(Marshal.SizeOf(PyObject))
+        objPtr = Marshal.AllocHGlobal(Marshal.SizeOf(PyObject()))
         addToCleanUp(lambda: Marshal.FreeHGlobal(objPtr))
         
         self.assertEquals(mapper.PyObject_Init(objPtr, typePtr), objPtr, 'did not return the "new instance"')
@@ -527,7 +527,7 @@ class NewInitFunctionsTest(TestCase):
         mapper = PythonMapper(allocator)
         deallocTypes = CreateTypes(mapper)
         
-        typeObjSize = Marshal.SizeOf(PyTypeObject)
+        typeObjSize = Marshal.SizeOf(PyTypeObject())
         typePtr = Marshal.AllocHGlobal(typeObjSize)
         CPyMarshal.Zero(typePtr, typeObjSize)
         CPyMarshal.WriteIntField(typePtr, PyTypeObject, "tp_basicsize", 31337)
@@ -549,7 +549,7 @@ class NewInitFunctionsTest(TestCase):
         mapper = PythonMapper(allocator)
         deallocTypes = CreateTypes(mapper)
         
-        typeObjSize = Marshal.SizeOf(PyTypeObject)
+        typeObjSize = Marshal.SizeOf(PyTypeObject())
         typePtr = Marshal.AllocHGlobal(typeObjSize)
         CPyMarshal.Zero(typePtr, typeObjSize)
         CPyMarshal.WriteIntField(typePtr, PyTypeObject, "tp_basicsize", 31337)

--- a/tests/cpymarshaltest.py
+++ b/tests/cpymarshaltest.py
@@ -50,8 +50,8 @@ class CPyMarshalTest_32(TestCase):
     
     
     def testWritePtrField(self):
-        data = Marshal.AllocHGlobal(Marshal.SizeOf(PyObject))
-        CPyMarshal.Zero(data, Marshal.SizeOf(PyObject))
+        data = Marshal.AllocHGlobal(Marshal.SizeOf(PyObject()))
+        CPyMarshal.Zero(data, Marshal.SizeOf(PyObject()))
         
         CPyMarshal.WritePtrField(data, PyObject, "ob_type", IntPtr(12345))
         dataStruct = Marshal.PtrToStructure(data, PyObject)
@@ -61,8 +61,8 @@ class CPyMarshalTest_32(TestCase):
     
     
     def testReadPtrField(self):
-        data = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject))
-        CPyMarshal.Zero(data, Marshal.SizeOf(PyTypeObject))
+        data = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject()))
+        CPyMarshal.Zero(data, Marshal.SizeOf(PyTypeObject()))
         
         CPyMarshal.WritePtrField(data, PyTypeObject, "tp_doc", IntPtr(12345))
         self.assertEquals(CPyMarshal.ReadPtrField(data, PyTypeObject, "tp_doc"), IntPtr(12345), "failed to read")
@@ -71,8 +71,8 @@ class CPyMarshalTest_32(TestCase):
     
     
     def testWriteIntField(self):
-        data = Marshal.AllocHGlobal(Marshal.SizeOf(PyIntObject))
-        CPyMarshal.Zero(data, Marshal.SizeOf(PyIntObject))
+        data = Marshal.AllocHGlobal(Marshal.SizeOf(PyIntObject()))
+        CPyMarshal.Zero(data, Marshal.SizeOf(PyIntObject()))
         
         for value in (Int32.MaxValue, Int32.MinValue):
             CPyMarshal.WriteIntField(data, PyIntObject, "ob_ival", value)
@@ -83,8 +83,8 @@ class CPyMarshalTest_32(TestCase):
     
     
     def testReadIntField(self):
-        data = Marshal.AllocHGlobal(Marshal.SizeOf(PyIntObject))
-        CPyMarshal.Zero(data, Marshal.SizeOf(PyIntObject))
+        data = Marshal.AllocHGlobal(Marshal.SizeOf(PyIntObject()))
+        CPyMarshal.Zero(data, Marshal.SizeOf(PyIntObject()))
         
         for value in (Int32.MaxValue, Int32.MinValue):
             CPyMarshal.WriteIntField(data, PyIntObject, "ob_ival", value)
@@ -94,8 +94,8 @@ class CPyMarshalTest_32(TestCase):
     
     
     def testWriteUIntField(self):
-        data = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject))
-        CPyMarshal.Zero(data, Marshal.SizeOf(PyTypeObject))
+        data = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject()))
+        CPyMarshal.Zero(data, Marshal.SizeOf(PyTypeObject()))
         
         for value in (UInt32.MaxValue, UInt32.MinValue):
             CPyMarshal.WriteUIntField(data, PyTypeObject, "tp_version_tag", value)
@@ -106,8 +106,8 @@ class CPyMarshalTest_32(TestCase):
     
     
     def testReadUIntField(self):
-        data = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject))
-        CPyMarshal.Zero(data, Marshal.SizeOf(PyTypeObject))
+        data = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject()))
+        CPyMarshal.Zero(data, Marshal.SizeOf(PyTypeObject()))
         
         for value in (UInt32.MaxValue, UInt32.MinValue):
             CPyMarshal.WriteUIntField(data, PyTypeObject, "tp_version_tag", value)
@@ -117,8 +117,8 @@ class CPyMarshalTest_32(TestCase):
     
     
     def testWriteDoubleField(self):
-        data = Marshal.AllocHGlobal(Marshal.SizeOf(PyFloatObject))
-        CPyMarshal.Zero(data, Marshal.SizeOf(PyFloatObject))
+        data = Marshal.AllocHGlobal(Marshal.SizeOf(PyFloatObject()))
+        CPyMarshal.Zero(data, Marshal.SizeOf(PyFloatObject()))
         
         CPyMarshal.WriteDoubleField(data, PyFloatObject, "ob_fval", 7.6e-5)
         dataStruct = Marshal.PtrToStructure(data, PyFloatObject)
@@ -128,8 +128,8 @@ class CPyMarshalTest_32(TestCase):
     
     
     def testReadDoubleField(self):
-        data = Marshal.AllocHGlobal(Marshal.SizeOf(PyFloatObject))
-        CPyMarshal.Zero(data, Marshal.SizeOf(PyFloatObject))
+        data = Marshal.AllocHGlobal(Marshal.SizeOf(PyFloatObject()))
+        CPyMarshal.Zero(data, Marshal.SizeOf(PyFloatObject()))
         
         CPyMarshal.WriteDoubleField(data, PyFloatObject, "ob_fval", -1.2e34)
         self.assertEquals(CPyMarshal.ReadDoubleField(data, PyFloatObject, "ob_fval"), -1.2e34)
@@ -138,8 +138,8 @@ class CPyMarshalTest_32(TestCase):
     
     
     def testWriteCStringField(self):
-        data = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject))
-        CPyMarshal.Zero(data, Marshal.SizeOf(PyTypeObject))
+        data = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject()))
+        CPyMarshal.Zero(data, Marshal.SizeOf(PyTypeObject()))
         string = "Hey, I am a string. I have tricksy \\escapes\\."
         CPyMarshal.WriteCStringField(data, PyTypeObject, "tp_doc", string)
         
@@ -149,8 +149,8 @@ class CPyMarshalTest_32(TestCase):
     
     
     def testReadCStringField(self):
-        data = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject))
-        CPyMarshal.Zero(data, Marshal.SizeOf(PyTypeObject))
+        data = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject()))
+        CPyMarshal.Zero(data, Marshal.SizeOf(PyTypeObject()))
         string = "Hey, I am a string. I have tricksy \\escapes\\."
         strPtr = Marshal.StringToHGlobalAnsi(string)
         CPyMarshal.WritePtrField(data, PyTypeObject, "tp_doc", strPtr)
@@ -162,8 +162,8 @@ class CPyMarshalTest_32(TestCase):
     
     
     def testReadCStringFieldEmpty(self):
-        data = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject))
-        CPyMarshal.Zero(data, Marshal.SizeOf(PyTypeObject))
+        data = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject()))
+        CPyMarshal.Zero(data, Marshal.SizeOf(PyTypeObject()))
         CPyMarshal.WritePtrField(data, PyTypeObject, "tp_doc", IntPtr.Zero)
         
         self.assertEquals(CPyMarshal.ReadCStringField(data, PyTypeObject, "tp_doc"), "", "failed to read correctly")
@@ -172,8 +172,8 @@ class CPyMarshalTest_32(TestCase):
     
     
     def testWriteFunctionPtrField(self):
-        data = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject))
-        CPyMarshal.Zero(data, Marshal.SizeOf(PyTypeObject))
+        data = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject()))
+        CPyMarshal.Zero(data, Marshal.SizeOf(PyTypeObject()))
         
         calls = []
         def TestFunc(selfPtr, argsPtr, kwargsPtr):
@@ -191,8 +191,8 @@ class CPyMarshalTest_32(TestCase):
         
     
     def testReadFunctionPtrField(self):
-        data = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject))
-        CPyMarshal.Zero(data, Marshal.SizeOf(PyTypeObject))
+        data = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject()))
+        CPyMarshal.Zero(data, Marshal.SizeOf(PyTypeObject()))
         
         calls = []
         def TestFunc(selfPtr, argsPtr, kwargsPtr):

--- a/tests/dicttest.py
+++ b/tests/dicttest.py
@@ -24,7 +24,7 @@ class DictTest(TestCase):
             del allocs[:]
             dictPtr = mapper.PyDict_New()
             self.assertEquals(mapper.RefCount(dictPtr), 1, "bad refcount")
-            self.assertEquals(allocs, [(dictPtr, Marshal.SizeOf(PyObject))], "did not allocate as expected")
+            self.assertEquals(allocs, [(dictPtr, Marshal.SizeOf(PyObject()))], "did not allocate as expected")
             self.assertEquals(CPyMarshal.ReadPtrField(dictPtr, PyObject, "ob_type"), mapper.PyDict_Type, "wrong type")
             dictObj = mapper.Retrieve(dictPtr)
             self.assertEquals(dictObj, {}, "retrieved unexpected value")
@@ -45,7 +45,7 @@ class DictTest(TestCase):
 
     @WithMapper
     def testStoreDictCreatesDictType(self, mapper, addToCleanUp):
-        typeBlock = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject))
+        typeBlock = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject()))
         addToCleanUp(lambda: Marshal.FreeHGlobal(typeBlock))
         mapper.RegisterData("PyDict_Type", typeBlock)
         
@@ -55,7 +55,7 @@ class DictTest(TestCase):
 
     @WithMapper
     def testStoreTypeDictCreatesDictTypeWhichWorks(self, mapper, addToCleanUp):
-        typeBlock = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject))
+        typeBlock = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject()))
         addToCleanUp(lambda: Marshal.FreeHGlobal(typeBlock))
         mapper.RegisterData("PyDict_Type", typeBlock)
         

--- a/tests/filetest.py
+++ b/tests/filetest.py
@@ -27,7 +27,7 @@ class PyFile_Type_Test(TestCase):
 
     @WithMapper
     def testPyFile_Type(self, mapper, addToCleanUp):
-        typeBlock = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject))
+        typeBlock = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject()))
         addToCleanUp(lambda: Marshal.FreeHGlobal(typeBlock))
         
         mapper.RegisterData("PyFile_Type", typeBlock)

--- a/tests/functiontest.py
+++ b/tests/functiontest.py
@@ -34,7 +34,7 @@ class FunctionTest(TestCase):
     @WithMapper
     def testStoreType(self, mapper, _):
         self.assertEquals(mapper.Retrieve(mapper.PyFunction_Type), FunctionType)
-        self.assertEquals(CPyMarshal.ReadIntField(mapper.PyFunction_Type, PyTypeObject, 'tp_basicsize'), Marshal.SizeOf(PyFunctionObject))
+        self.assertEquals(CPyMarshal.ReadIntField(mapper.PyFunction_Type, PyTypeObject, 'tp_basicsize'), Marshal.SizeOf(PyFunctionObject()))
 
 suite = makesuite(FunctionTest)
 if __name__ == '__main__':

--- a/tests/interestingptrmaptest.py
+++ b/tests/interestingptrmaptest.py
@@ -32,7 +32,7 @@ class InterestingPtrMapTest(TestCase):
     
     def getVars(self):
         obj = object()
-        ptr = Marshal.AllocHGlobal(Marshal.SizeOf(PyObject))
+        ptr = Marshal.AllocHGlobal(Marshal.SizeOf(PyObject()))
         CPyMarshal.WriteIntField(ptr, PyObject, 'ob_refcnt', 1)
         self.ptrs.append(ptr)
         return InterestingPtrMap(), ptr, obj, WeakReference(obj)

--- a/tests/listtest.py
+++ b/tests/listtest.py
@@ -25,7 +25,7 @@ class PyList_Type_Test(TypeTestCase):
         
         mapper = MyPM()
         
-        typeBlock = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject))
+        typeBlock = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject()))
         mapper.RegisterData("PyList_Type", typeBlock)
         gcwait() # this will make the function pointers invalid if we forgot to store references to the delegates
 
@@ -118,7 +118,7 @@ class ListFunctionsTest(TestCase):
         
         del allocs[:]
         listPtr = mapper.PyList_New(0)
-        self.assertEquals(allocs, [(listPtr, Marshal.SizeOf(PyListObject))], "bad alloc")
+        self.assertEquals(allocs, [(listPtr, Marshal.SizeOf(PyListObject()))], "bad alloc")
 
         listStruct = Marshal.PtrToStructure(listPtr, PyListObject)
         self.assertEquals(listStruct.ob_refcnt, 1, "bad refcount")
@@ -150,7 +150,7 @@ class ListFunctionsTest(TestCase):
         dataPtr = listStruct.ob_item
         self.assertNotEquals(dataPtr, IntPtr.Zero, "failed to allocate space for data")
         
-        expectedAllocs = [(dataPtr, (SIZE * CPyMarshal.PtrSize)), (listPtr, Marshal.SizeOf(PyListObject))]
+        expectedAllocs = [(dataPtr, (SIZE * CPyMarshal.PtrSize)), (listPtr, Marshal.SizeOf(PyListObject()))]
         self.assertEquals(set(allocs), set(expectedAllocs), "allocated wrong")
         
         for _ in range(SIZE):
@@ -169,7 +169,7 @@ class ListFunctionsTest(TestCase):
         
         del allocs[:]
         listPtr = mapper.PyList_New(0)
-        self.assertEquals(allocs, [(listPtr, Marshal.SizeOf(PyListObject))], "bad alloc")
+        self.assertEquals(allocs, [(listPtr, Marshal.SizeOf(PyListObject()))], "bad alloc")
 
         item1 = object()
         item2 = object()

--- a/tests/numberstest.py
+++ b/tests/numberstest.py
@@ -16,7 +16,7 @@ class PyBool_Test(TestCase):
     
     @WithMapper
     def testTrueFalse(self, mapper, _):
-        truePtr = Marshal.AllocHGlobal(Marshal.SizeOf(PyIntObject))
+        truePtr = Marshal.AllocHGlobal(Marshal.SizeOf(PyIntObject()))
         mapper.RegisterData("_Py_TrueStruct", truePtr)
         self.assertTrue(mapper.Retrieve(truePtr) is True)
         self.assertEquals(CPyMarshal.ReadPtrField(truePtr, PyIntObject, 'ob_type'), mapper.PyBool_Type)
@@ -26,7 +26,7 @@ class PyBool_Test(TestCase):
         self.assertEquals(truePtr2, truePtr)
         self.assertEquals(mapper.RefCount(truePtr), 2)
         
-        falsePtr = Marshal.AllocHGlobal(Marshal.SizeOf(PyIntObject))
+        falsePtr = Marshal.AllocHGlobal(Marshal.SizeOf(PyIntObject()))
         mapper.RegisterData("_Py_ZeroStruct", falsePtr)
         self.assertTrue(mapper.Retrieve(falsePtr) is False)
         self.assertEquals(CPyMarshal.ReadPtrField(falsePtr, PyIntObject, 'ob_type'), mapper.PyBool_Type)
@@ -378,7 +378,7 @@ class PyFloat_Test(TestCase):
 
     @WithMapper
     def testActualiseFloat(self, mapper, call_later):
-        fptr = Marshal.AllocHGlobal(Marshal.SizeOf(PyFloatObject))
+        fptr = Marshal.AllocHGlobal(Marshal.SizeOf(PyFloatObject()))
         call_later(lambda: Marshal.FreeHGlobal(fptr))
         CPyMarshal.WritePtrField(fptr, PyFloatObject, "ob_type", mapper.PyFloat_Type)
         CPyMarshal.WriteIntField(fptr, PyFloatObject, "ob_refcnt", 1)

--- a/tests/pythonapitest.py
+++ b/tests/pythonapitest.py
@@ -29,14 +29,14 @@ def GetWriteBytes(bytes):
             Marshal.WriteInt32(ptr, TEST_NUMBER)
     return WriteBytes
 
-WritePyTypeObject =  GetWriteBytes(Marshal.SizeOf(PyTypeObject))
-TestWrotePyTypeObject = GetTestWroteBytes(Marshal.SizeOf(PyTypeObject))
+WritePyTypeObject =  GetWriteBytes(Marshal.SizeOf(PyTypeObject()))
+TestWrotePyTypeObject = GetTestWroteBytes(Marshal.SizeOf(PyTypeObject()))
 
-WritePyObject = GetWriteBytes(Marshal.SizeOf(PyObject))
-TestWrotePyObject = GetTestWroteBytes(Marshal.SizeOf(PyObject))
+WritePyObject = GetWriteBytes(Marshal.SizeOf(PyObject()))
+TestWrotePyObject = GetTestWroteBytes(Marshal.SizeOf(PyObject()))
 
-WritePtr = GetWriteBytes(Marshal.SizeOf(IntPtr))
-TestWrotePtr = GetTestWroteBytes(Marshal.SizeOf(IntPtr))
+WritePtr = GetWriteBytes(Marshal.SizeOf(IntPtr()))
+TestWrotePtr = GetTestWroteBytes(Marshal.SizeOf(IntPtr()))
 
 TYPES = (
     "PyBool_Type",
@@ -101,14 +101,14 @@ class PythonApiTest(TestCase):
         class MyPM(PythonApi):
             def Register__Py_NoneStruct(self, address):
                 WritePyObject(address)
-        self.assertDataSetterSetsAndRemembers(MyPM, "_Py_NoneStruct", Marshal.SizeOf(PyObject), TestWrotePyObject)
+        self.assertDataSetterSetsAndRemembers(MyPM, "_Py_NoneStruct", Marshal.SizeOf(PyObject()), TestWrotePyObject)
 
 
     def testFinds_Py_NotImplementedStruct(self):
         class MyPM(PythonApi):
             def Register__Py_NotImplementedStruct(self, address):
                 WritePyObject(address)
-        self.assertDataSetterSetsAndRemembers(MyPM, "_Py_NotImplementedStruct", Marshal.SizeOf(PyObject), TestWrotePyObject)
+        self.assertDataSetterSetsAndRemembers(MyPM, "_Py_NotImplementedStruct", Marshal.SizeOf(PyObject()), TestWrotePyObject)
 
 
     def testFinds_PyExc_OverflowError(self):
@@ -117,7 +117,7 @@ class PythonApiTest(TestCase):
         class MyPM(PythonApi):
             def Register_PyExc_OverflowError(self, address):
                 WritePtr(address)
-        self.assertDataSetterSetsAndRemembers(MyPM, "PyExc_OverflowError", Marshal.SizeOf(PyObject), TestWrotePtr)
+        self.assertDataSetterSetsAndRemembers(MyPM, "PyExc_OverflowError", Marshal.SizeOf(PyObject()), TestWrotePtr)
         
 
     def assertFindsType(self, name):
@@ -125,7 +125,7 @@ class PythonApiTest(TestCase):
             def fillmethod(self, address):
                 WritePyTypeObject(address)
         setattr(MyPM, "Register_" + name, getattr(MyPM, "fillmethod"))
-        self.assertDataSetterSetsAndRemembers(MyPM, name, Marshal.SizeOf(PyTypeObject), TestWrotePyTypeObject)
+        self.assertDataSetterSetsAndRemembers(MyPM, name, Marshal.SizeOf(PyTypeObject()), TestWrotePyTypeObject)
 
 
     def testFindsTypes(self):

--- a/tests/pythonmapper_core_test.py
+++ b/tests/pythonmapper_core_test.py
@@ -142,7 +142,7 @@ class PythonMapper_CreateDestroy_Test(TestCase):
     
     def testIgnoresBridgeObjectsNotAllocatedByAllocator(self):
         obj = object()
-        ptr = Marshal.AllocHGlobal(Marshal.SizeOf(PyObject))
+        ptr = Marshal.AllocHGlobal(Marshal.SizeOf(PyObject()))
         CPyMarshal.WriteIntField(ptr, PyObject, 'ob_refcnt', 2)
         
         mapper = PythonMapper()
@@ -163,7 +163,7 @@ class PythonMapper_References_Test(TestCase):
         obj1 = object()
         ptr = mapper.Store(obj1)
         self.assertEquals(len(allocs), 1, "unexpected number of allocations")
-        self.assertEquals(allocs[0], (ptr, Marshal.SizeOf(PyObject)), "unexpected result")
+        self.assertEquals(allocs[0], (ptr, Marshal.SizeOf(PyObject())), "unexpected result")
         self.assertNotEquals(ptr, IntPtr.Zero, "did not store reference")
         self.assertEquals(mapper.RefCount(ptr), 1, "unexpected refcount")
         self.assertEquals(CPyMarshal.ReadPtrField(ptr, PyObject, "ob_type"), 
@@ -205,7 +205,7 @@ class PythonMapper_References_Test(TestCase):
         result1 = mapper.Store(obj1)
         result2 = mapper.Store(obj1)
         
-        self.assertEquals(allocs, [(result1, Marshal.SizeOf(PyObject))], "unexpected result")
+        self.assertEquals(allocs, [(result1, Marshal.SizeOf(PyObject()))], "unexpected result")
         self.assertEquals(result1, result2, "did not return same ptr")
         self.assertEquals(mapper.RefCount(result1), 2, "did not incref")
         
@@ -217,7 +217,7 @@ class PythonMapper_References_Test(TestCase):
         
         result3 = mapper.Store(obj1)
         self.assertEquals(allocs, 
-                          [(result1, Marshal.SizeOf(PyObject)), (result3, Marshal.SizeOf(PyObject))], 
+                          [(result1, Marshal.SizeOf(PyObject())), (result3, Marshal.SizeOf(PyObject()))], 
                           "unexpected result -- failed to clear reverse mapping?")
         mapper.Dispose()
         deallocTypes()
@@ -249,7 +249,7 @@ class PythonMapper_References_Test(TestCase):
         deallocTypes = CreateTypes(mapper)
         
         # need to use same allocator as mapper, otherwise it gets upset on shutdown
-        objPtr = allocator.Alloc(Marshal.SizeOf(PyObject))
+        objPtr = allocator.Alloc(Marshal.SizeOf(PyObject()))
         CPyMarshal.WriteIntField(objPtr, PyObject, "ob_refcnt", 0)
         CPyMarshal.WritePtrField(objPtr, PyObject, "ob_type", mapper.PyBaseObject_Type)
         mapper.StoreBridge(objPtr, object())
@@ -267,7 +267,7 @@ class PythonMapper_References_Test(TestCase):
         deallocDgt = dgt_void_ptr(TypeDealloc)
         deallocFP = Marshal.GetFunctionPointerForDelegate(deallocDgt)
         
-        typePtr = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject))
+        typePtr = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject()))
         deallocPtr = CPyMarshal.Offset(typePtr, Marshal.OffsetOf(PyTypeObject, "tp_dealloc"))
         CPyMarshal.WritePtr(deallocPtr, deallocFP)
         
@@ -287,7 +287,7 @@ class PythonMapper_References_Test(TestCase):
         mapper = PythonMapper(GetAllocatingTestAllocator([], frees))
         deallocTypes = CreateTypes(mapper)
         
-        typePtr = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject))
+        typePtr = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject()))
         CPyMarshal.WritePtrField(typePtr, PyTypeObject, "tp_dealloc", IntPtr.Zero)
         
         obj = object()
@@ -310,7 +310,7 @@ class PythonMapper_References_Test(TestCase):
         mapper = PythonMapper(allocator)
         deallocTypes = CreateTypes(mapper)
         # need to use same allocator as mapper, otherwise it gets upset on shutdown
-        ptr = allocator.Alloc(Marshal.SizeOf(PyObject))
+        ptr = allocator.Alloc(Marshal.SizeOf(PyObject()))
         
         try:
             def do():
@@ -353,7 +353,7 @@ class PythonMapper_References_Test(TestCase):
         deallocTypes = CreateTypes(mapper)
 
         # need to use same allocator as mapper, otherwise it gets upset on shutdown
-        ptr = allocator.Alloc(Marshal.SizeOf(PyObject))
+        ptr = allocator.Alloc(Marshal.SizeOf(PyObject()))
         
         try:
             def do1():
@@ -398,7 +398,7 @@ class PythonMapper_References_Test(TestCase):
             obj = object()
             ref = WeakReference(obj)
             # need to use same allocator as mapper, otherwise it gets upset on shutdown
-            ptr = allocator.Alloc(Marshal.SizeOf(PyObject))
+            ptr = allocator.Alloc(Marshal.SizeOf(PyObject()))
             CPyMarshal.WriteIntField(ptr, PyObject, "ob_refcnt", 2)
             CPyMarshal.WritePtrField(ptr, PyObject, "ob_type", mapper.PyBaseObject_Type)
             mapper.StoreBridge(ptr, obj)
@@ -663,7 +663,7 @@ class PythonMapper_Py_OptimizeFlag_Test(TestCase):
         # TODO: if we set a lower value, numpy will crash inside arr_add_docstring
         # I consider docstrings to be low-priority-enough that it's OK to fudge this
         # for now. also, fixing it would be hard ;).
-        flagPtr = Marshal.AllocHGlobal(Marshal.SizeOf(Int32))
+        flagPtr = Marshal.AllocHGlobal(Marshal.SizeOf(Int32()))
         addToCleanUp(lambda: Marshal.FreeHGlobal(flagPtr))
         mapper.RegisterData("Py_OptimizeFlag", flagPtr)
         

--- a/tests/retrievetypetest.py
+++ b/tests/retrievetypetest.py
@@ -168,7 +168,7 @@ class InheritanceTest(TestCase):
         for base in bases:
             self.assertEquals(issubclass(klass, base), True)
 
-        unknownInstancePtr = Marshal.AllocHGlobal(Marshal.SizeOf(PyIntObject))
+        unknownInstancePtr = Marshal.AllocHGlobal(Marshal.SizeOf(PyIntObject()))
         addToCleanUp(lambda: Marshal.FreeHGlobal(unknownInstancePtr))
 
         CPyMarshal.WriteIntField(unknownInstancePtr, PyObject, "ob_refcnt", 1)
@@ -244,7 +244,7 @@ class InheritanceTest(TestCase):
         metaclassSpec = CreateTypeSpec('metaclass')
         metaclassSpec['tp_base'] = mapper.PyType_Type
         metaclassSpec['tp_init'] = lambda _, __, ___: 0
-        metaclassSpec['tp_basicsize'] = Marshal.SizeOf(PyTypeObject)
+        metaclassSpec['tp_basicsize'] = Marshal.SizeOf(PyTypeObject())
         metaclassPtr, deallocMeta = MakeTypePtr(mapper, metaclassSpec)
         CallLater(deallocMeta)
         metaclass = mapper.Retrieve(metaclassPtr)
@@ -285,18 +285,18 @@ class BuiltinSubclassHorrorTest(TestCase):
         typeSpec = {
             'tp_name': 'klass',
             'tp_base': mapper.PyInt_Type,
-            'tp_basicsize': Marshal.SizeOf(PyIntObject)
+            'tp_basicsize': Marshal.SizeOf(PyIntObject())
         }
         klassPtr, deallocType = MakeTypePtr(mapper, typeSpec)
         deallocLater(deallocType)
         
-        _12Ptr = Marshal.AllocHGlobal(Marshal.SizeOf(PyIntObject))
+        _12Ptr = Marshal.AllocHGlobal(Marshal.SizeOf(PyIntObject()))
         deallocLater(lambda: Marshal.FreeHGlobal(_12Ptr))
         CPyMarshal.WriteIntField(_12Ptr, PyIntObject, "ob_refcnt", 1)
         CPyMarshal.WritePtrField(_12Ptr, PyIntObject, "ob_type", klassPtr)
         CPyMarshal.WriteIntField(_12Ptr, PyIntObject, "ob_ival", 12)
         
-        _44Ptr = Marshal.AllocHGlobal(Marshal.SizeOf(PyIntObject))
+        _44Ptr = Marshal.AllocHGlobal(Marshal.SizeOf(PyIntObject()))
         deallocLater(lambda: Marshal.FreeHGlobal(_44Ptr))
         CPyMarshal.WriteIntField(_44Ptr, PyIntObject, "ob_refcnt", 1)
         CPyMarshal.WritePtrField(_44Ptr, PyIntObject, "ob_type", klassPtr)
@@ -312,13 +312,13 @@ class BuiltinSubclassHorrorTest(TestCase):
         typeSpec = {
             'tp_name': 'klass',
             'tp_base': mapper.PyString_Type,
-            'tp_basicsize': Marshal.SizeOf(PyStringObject) - 1,
+            'tp_basicsize': Marshal.SizeOf(PyStringObject()) - 1,
             'tp_itemsize': 1,
         }
         klassPtr, deallocType = MakeTypePtr(mapper, typeSpec)
         deallocLater(deallocType)
         
-        _f0oSize = Marshal.SizeOf(PyStringObject) + 3
+        _f0oSize = Marshal.SizeOf(PyStringObject()) + 3
         _f0oPtr = Marshal.AllocHGlobal(_f0oSize)
         CPyMarshal.Zero(_f0oPtr, _f0oSize)
         deallocLater(lambda: Marshal.FreeHGlobal(_f0oPtr))
@@ -344,7 +344,7 @@ class BuiltinSubclassHorrorTest(TestCase):
         metaclassSpec = {
             'tp_name': 'meta',
             'tp_base': mapper.PyType_Type,
-            'tp_basicsize': Marshal.SizeOf(PyTypeObject)
+            'tp_basicsize': Marshal.SizeOf(PyTypeObject())
         }
         metaclassPtr, deallocMeta = MakeTypePtr(mapper, metaclassSpec)
         CallLater(deallocMeta)

--- a/tests/slicetest.py
+++ b/tests/slicetest.py
@@ -74,10 +74,10 @@ class SliceTest(TestCase):
 
     @WithMapper
     def testCreateEllipsis(self, mapper, addToCleanUp):
-        ellipsisTypePtr = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject))
+        ellipsisTypePtr = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject()))
         addToCleanUp(lambda: Marshal.FreeHGlobal(ellipsisTypePtr))
 
-        ellipsisPtr = Marshal.AllocHGlobal(Marshal.SizeOf(PyObject))
+        ellipsisPtr = Marshal.AllocHGlobal(Marshal.SizeOf(PyObject()))
         addToCleanUp(lambda: Marshal.FreeHGlobal(ellipsisPtr))
 
         mapper.RegisterData("PyEllipsis_Type", ellipsisTypePtr)

--- a/tests/stringtest.py
+++ b/tests/stringtest.py
@@ -125,7 +125,7 @@ class PyString_Type_Test(TypeTestCase):
         getcharbuffer = CPyMarshal.ReadFunctionPtrField(bufPtr, PyBufferProcs, 'bf_getcharbuffer', dgt_int_ptrintptr)
         getsegcount = CPyMarshal.ReadFunctionPtrField(bufPtr, PyBufferProcs, 'bf_getsegcount', dgt_int_ptrptr)
         
-        ptrptr = Marshal.AllocHGlobal(Marshal.SizeOf(IntPtr))
+        ptrptr = Marshal.AllocHGlobal(Marshal.SizeOf(IntPtr()))
         later(lambda: Marshal.FreeHGlobal(ptrptr))
         
         strptr = mapper.Store("hullo")
@@ -155,7 +155,7 @@ class PyString_FromString_Test(PyString_TestCase):
         testData = self.ptrFromByteArray(bytes)
         try:
             strPtr = mapper.PyString_FromString(testData)
-            baseSize = Marshal.SizeOf(PyStringObject)
+            baseSize = Marshal.SizeOf(PyStringObject())
             self.assertEquals(allocs, [(strPtr, len(bytes) + baseSize)], "allocated wrong")
             self.assertStringObjectHasLength(strPtr, len(bytes))
             self.assertStringObjectHasDataBytes(strPtr, bytes)
@@ -175,7 +175,7 @@ class PyString_Concat_Test(PyString_TestCase):
         part2Ptr = mapper.Store(" three")
         startingRefCnt = mapper.RefCount(part1Ptr)
         
-        stringPtrPtr = Marshal.AllocHGlobal(Marshal.SizeOf(IntPtr))
+        stringPtrPtr = Marshal.AllocHGlobal(Marshal.SizeOf(IntPtr()))
         addToCleanup(lambda: Marshal.FreeHGlobal(stringPtrPtr))
         
         Marshal.WriteIntPtr(stringPtrPtr, part1Ptr)
@@ -196,7 +196,7 @@ class PyString_Concat_Test(PyString_TestCase):
         startingRefCnt = mapper.RefCount(part1Ptr)
         
         part2Ptr = mapper.Store(3)
-        stringPtrPtr = Marshal.AllocHGlobal(Marshal.SizeOf(IntPtr))
+        stringPtrPtr = Marshal.AllocHGlobal(Marshal.SizeOf(IntPtr()))
         addToCleanup(lambda: Marshal.FreeHGlobal(stringPtrPtr))
         
         Marshal.WriteIntPtr(stringPtrPtr, part1Ptr)
@@ -214,7 +214,7 @@ class PyString_Concat_Test(PyString_TestCase):
         startingRefCnt = mapper.RefCount(part1Ptr)
 
         part2Ptr = mapper.Store("three")
-        stringPtrPtr = Marshal.AllocHGlobal(Marshal.SizeOf(IntPtr))
+        stringPtrPtr = Marshal.AllocHGlobal(Marshal.SizeOf(IntPtr()))
         addToCleanup(lambda: Marshal.FreeHGlobal(stringPtrPtr))
         
         Marshal.WriteIntPtr(stringPtrPtr, part1Ptr)
@@ -237,7 +237,7 @@ class PyString_ConcatAndDel_Test(PyString_TestCase):
         mapper.IncRef(part2Ptr) # avoid garbage collection
         startingPart2RefCnt = mapper.RefCount(part2Ptr)
 
-        stringPtrPtr = Marshal.AllocHGlobal(Marshal.SizeOf(IntPtr))
+        stringPtrPtr = Marshal.AllocHGlobal(Marshal.SizeOf(IntPtr()))
         addToCleanup(lambda: Marshal.FreeHGlobal(stringPtrPtr))
         
         Marshal.WriteIntPtr(stringPtrPtr, part1Ptr)
@@ -272,7 +272,7 @@ class InternTest(PyString_TestCase):
         self.assertEquals(mapper.RefCount(sp2), 2, 'failed to grab extra reference to induce immortality')
         
         mapper.IncRef(sp1)
-        sp1p = Marshal.AllocHGlobal(Marshal.SizeOf(IntPtr))
+        sp1p = Marshal.AllocHGlobal(Marshal.SizeOf(IntPtr()))
         CPyMarshal.WritePtr(sp1p, sp1)
         mapper.PyString_InternInPlace(sp1p)
         sp1i = CPyMarshal.ReadPtr(sp1p)
@@ -295,7 +295,7 @@ class PyString_FromStringAndSize_Test(PyString_TestCase):
             testString = "we run the grease racket in this town" + self.getStringWithValues(0, 256)
             testLength = len(testString)
             strPtr = mapper.PyString_FromStringAndSize(IntPtr.Zero, testLength)
-            baseSize = Marshal.SizeOf(PyStringObject)
+            baseSize = Marshal.SizeOf(PyStringObject())
             self.assertEquals(allocs, [(strPtr, testLength + baseSize)], "allocated wrong")
             self.assertStringObjectHasLength(strPtr, testLength)
             self.assertHasStringType(strPtr, mapper)
@@ -326,7 +326,7 @@ class PyString_FromStringAndSize_Test(PyString_TestCase):
             testLength = len(testString)
 
             strPtr = mapper.PyString_FromStringAndSize(testData, testLength)
-            baseSize = Marshal.SizeOf(PyStringObject)
+            baseSize = Marshal.SizeOf(PyStringObject())
             self.assertEquals(allocs, [(strPtr, testLength + baseSize)], "allocated wrong")
             self.assertHasStringType(strPtr, mapper)
             self.assertStringObjectHasLength(strPtr, testLength)
@@ -345,12 +345,12 @@ class _PyString_Resize_Test(PyString_TestCase):
         mapper = PythonMapper(GetAllocatingTestAllocator(allocs, frees))
         deallocTypes = CreateTypes(mapper)
         del allocs[:]
-        ptrPtr = Marshal.AllocHGlobal(Marshal.SizeOf(IntPtr))
+        ptrPtr = Marshal.AllocHGlobal(Marshal.SizeOf(IntPtr()))
 
         try:
             data = mapper.PyString_FromStringAndSize(IntPtr.Zero, 365)
             Marshal.WriteIntPtr(ptrPtr, data)
-            baseSize = Marshal.SizeOf(PyStringObject)
+            baseSize = Marshal.SizeOf(PyStringObject())
             self.assertEquals(allocs, [(data, 365 + baseSize)], "allocated wrong")
             self.assertEquals(mapper._PyString_Resize(ptrPtr, 2000000000), -1, "bad return on error")
             self.assertEquals(type(mapper.LastException), MemoryError, "wrong exception type")
@@ -370,13 +370,13 @@ class _PyString_Resize_Test(PyString_TestCase):
 
         oldLength = 365
         newLength = 20
-        ptrPtr = Marshal.AllocHGlobal(Marshal.SizeOf(IntPtr))
+        ptrPtr = Marshal.AllocHGlobal(Marshal.SizeOf(IntPtr()))
 
         try:
             strPtr = mapper.PyString_FromStringAndSize(IntPtr.Zero, oldLength)
             Marshal.WriteIntPtr(ptrPtr, strPtr)
             
-            baseSize = Marshal.SizeOf(PyStringObject)
+            baseSize = Marshal.SizeOf(PyStringObject())
             self.assertEquals(allocs, [(strPtr, oldLength + baseSize)], "allocated wrong")
             self.assertEquals(mapper._PyString_Resize(ptrPtr, newLength), 0, "bad return on success")
             
@@ -403,13 +403,13 @@ class _PyString_Resize_Test(PyString_TestCase):
         newLength = len(testString)
 
         oldStrPtr = mapper.PyString_FromStringAndSize(IntPtr.Zero, oldLength)
-        ptrPtr = Marshal.AllocHGlobal(Marshal.SizeOf(IntPtr))
+        ptrPtr = Marshal.AllocHGlobal(Marshal.SizeOf(IntPtr()))
         
         try:
             Marshal.WriteIntPtr(ptrPtr, oldStrPtr)
             newStrPtr = IntPtr.Zero
             
-            baseSize = Marshal.SizeOf(PyStringObject)
+            baseSize = Marshal.SizeOf(PyStringObject())
             self.assertEquals(allocs, [(oldStrPtr, oldLength + baseSize)], "allocated wrong")
             self.assertEquals(mapper._PyString_Resize(ptrPtr, newLength), 0, "bad return on success")
 
@@ -580,7 +580,7 @@ class PyStringStoreTest(PyString_TestCase):
 
         try:
             strPtr = mapper.Store(testString)
-            baseSize = Marshal.SizeOf(PyStringObject)
+            baseSize = Marshal.SizeOf(PyStringObject())
             
             self.assertEquals(allocs, [(strPtr, testLength + baseSize)], "allocated wrong")
             self.assertHasStringType(strPtr, mapper)

--- a/tests/tupletest.py
+++ b/tests/tupletest.py
@@ -92,10 +92,10 @@ class TupleTest(TestCase):
         allocs = []
         mapper = PythonMapper(GetAllocatingTestAllocator(allocs, []))
 
-        typeBlock = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject))
+        typeBlock = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject()))
         mapper.RegisterData("PyTuple_Type", typeBlock)
         tuplePtr = mapper.PyTuple_New(length)
-        expectedSize = Marshal.SizeOf(PyTupleObject) + (CPyMarshal.PtrSize * (length - 1))
+        expectedSize = Marshal.SizeOf(PyTupleObject()) + (CPyMarshal.PtrSize * (length - 1))
         self.assertEquals(allocs, [(tuplePtr, expectedSize)], "bad alloc")
         tupleStruct = Marshal.PtrToStructure(tuplePtr, PyTupleObject)
         self.assertEquals(tupleStruct.ob_refcnt, 1, "bad refcount")
@@ -144,7 +144,7 @@ class TupleTest(TestCase):
         self.assertEquals(mapper._PyTuple_Resize(tuplePtrPtr, 100), 0)
 
         newTuplePtr = CPyMarshal.ReadPtr(tuplePtrPtr)
-        expectedSize = Marshal.SizeOf(PyTupleObject) + (CPyMarshal.PtrSize * (99))
+        expectedSize = Marshal.SizeOf(PyTupleObject()) + (CPyMarshal.PtrSize * (99))
         self.assertEquals(allocs, [(newTuplePtr, expectedSize)])
         
         tupleStruct = Marshal.PtrToStructure(newTuplePtr, PyTupleObject)
@@ -171,7 +171,7 @@ class TupleTest(TestCase):
         allocs = []
         mapper = PythonMapper(GetAllocatingTestAllocator(allocs, []))
         
-        typeBlock = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject))
+        typeBlock = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject()))
         mapper.RegisterData("PyTuple_Type", typeBlock)
 
         theTuple = (0, 1, 2)

--- a/tests/typestest.py
+++ b/tests/typestest.py
@@ -135,7 +135,7 @@ class Types_Test(TestCase):
 
     @WithMapper
     def testPyType_IsSubtype_NullPtrs(self, mapper, CallLater):
-        type_size = Marshal.SizeOf(PyTypeObject)
+        type_size = Marshal.SizeOf(PyTypeObject())
         ptr = Marshal.AllocHGlobal(type_size)
         CallLater(lambda: Marshal.FreeHGlobal(ptr))
         CPyMarshal.Zero(ptr, type_size)
@@ -146,8 +146,8 @@ class Types_Test(TestCase):
 
     @WithMapper
     def testPyType_Ready(self, mapper, addToCleanUp):
-        typePtr = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject))
-        CPyMarshal.Zero(typePtr, Marshal.SizeOf(PyTypeObject))
+        typePtr = Marshal.AllocHGlobal(Marshal.SizeOf(PyTypeObject()))
+        CPyMarshal.Zero(typePtr, Marshal.SizeOf(PyTypeObject()))
         addToCleanUp(lambda: Marshal.FreeHGlobal(typePtr))
 
         self.assertEquals(mapper.PyType_Ready(typePtr), 0, "wrong")
@@ -194,7 +194,7 @@ class Types_Test(TestCase):
         discoveryModes = ("IncRef", "Retrieve", "DecRef", "RefCount")
         for _type in filter(lambda s: s not in safeTypes, BUILTIN_TYPES):
             for mode in discoveryModes:
-                objPtr = Marshal.AllocHGlobal(Marshal.SizeOf(PyObject))
+                objPtr = Marshal.AllocHGlobal(Marshal.SizeOf(PyObject()))
                 CPyMarshal.WriteIntField(objPtr, PyObject, "ob_refcnt", 2)
                 CPyMarshal.WritePtrField(objPtr, PyObject, "ob_type", getattr(mapper, _type))
                 self.assertRaises(CannotInterpretException, getattr(mapper, mode), objPtr)
@@ -268,7 +268,7 @@ class Types_Test(TestCase):
             for (mode, TestFunc) in discoveryModes.items():
                 typePtr, deallocType = MakeTypePtr(mapper, {"tp_name": mode + "Class"})
                 userTypeDeallocs.append(deallocType)
-                objPtr = allocator.Alloc(Marshal.SizeOf(PyObject))
+                objPtr = allocator.Alloc(Marshal.SizeOf(PyObject()))
                 CPyMarshal.WriteIntField(objPtr, PyObject, "ob_refcnt", 2)
                 CPyMarshal.WritePtrField(objPtr, PyObject, "ob_type", typePtr)
                 
@@ -298,7 +298,7 @@ class Types_Test(TestCase):
         baseFlags = CPyMarshal.ReadIntField(cPtr, PyTypeObject, "tp_flags")
         self.assertEquals(baseFlags & UInt32(Py_TPFLAGS.READY), UInt32(Py_TPFLAGS.READY), "did not ready newly-stored type")
         
-        instancePtr = Marshal.AllocHGlobal(Marshal.SizeOf(PyObject))
+        instancePtr = Marshal.AllocHGlobal(Marshal.SizeOf(PyObject()))
         CPyMarshal.WritePtrField(instancePtr, PyObject, "ob_type", cPtr)
         CPyMarshal.WriteIntField(instancePtr, PyObject, "ob_refcnt", 2)
         
@@ -324,18 +324,18 @@ class Types_Test(TestCase):
 
     @WithMapper
     def testSizes(self, mapper, _):
-        self.assertSizes(mapper.PyBaseObject_Type, Marshal.SizeOf(PyObject))
-        self.assertSizes(mapper.PyType_Type, Marshal.SizeOf(PyTypeObject))
-        self.assertSizes(mapper.PyTuple_Type, Marshal.SizeOf(PyTupleObject), Marshal.SizeOf(IntPtr)) # bigger than necessary
-        self.assertSizes(mapper.PyString_Type, Marshal.SizeOf(PyStringObject) - 1, Marshal.SizeOf(Byte))
-        self.assertSizes(mapper.PyList_Type, Marshal.SizeOf(PyListObject))
-        self.assertSizes(mapper.PySlice_Type, Marshal.SizeOf(PySliceObject))
-        self.assertSizes(mapper.PyMethod_Type, Marshal.SizeOf(PyMethodObject))
-        self.assertSizes(mapper.PyInt_Type, Marshal.SizeOf(PyIntObject))
-        self.assertSizes(mapper.PyFloat_Type, Marshal.SizeOf(PyFloatObject))
-        self.assertSizes(mapper.PyComplex_Type, Marshal.SizeOf(PyComplexObject))
-        self.assertSizes(mapper.PyClass_Type, Marshal.SizeOf(PyClassObject))
-        self.assertSizes(mapper.PyInstance_Type, Marshal.SizeOf(PyInstanceObject))
+        self.assertSizes(mapper.PyBaseObject_Type, Marshal.SizeOf(PyObject()))
+        self.assertSizes(mapper.PyType_Type, Marshal.SizeOf(PyTypeObject()))
+        self.assertSizes(mapper.PyTuple_Type, Marshal.SizeOf(PyTupleObject()), Marshal.SizeOf(IntPtr())) # bigger than necessary
+        self.assertSizes(mapper.PyString_Type, Marshal.SizeOf(PyStringObject()) - 1, Marshal.SizeOf(Byte()))
+        self.assertSizes(mapper.PyList_Type, Marshal.SizeOf(PyListObject()))
+        self.assertSizes(mapper.PySlice_Type, Marshal.SizeOf(PySliceObject()))
+        self.assertSizes(mapper.PyMethod_Type, Marshal.SizeOf(PyMethodObject()))
+        self.assertSizes(mapper.PyInt_Type, Marshal.SizeOf(PyIntObject()))
+        self.assertSizes(mapper.PyFloat_Type, Marshal.SizeOf(PyFloatObject()))
+        self.assertSizes(mapper.PyComplex_Type, Marshal.SizeOf(PyComplexObject()))
+        self.assertSizes(mapper.PyClass_Type, Marshal.SizeOf(PyClassObject()))
+        self.assertSizes(mapper.PyInstance_Type, Marshal.SizeOf(PyInstanceObject()))
 
 
 class OldStyle_Test(TestCase):
@@ -433,7 +433,7 @@ class PyType_GenericAlloc_Test(TestCase):
         instanceType = CPyMarshal.ReadPtrField(result, PyObject, "ob_type")
         self.assertEquals(instanceType, typePtr, "bad type ptr")
         
-        headerSize = Marshal.SizeOf(PyObject)
+        headerSize = Marshal.SizeOf(PyObject())
         zerosPtr = OffsetPtr(result, headerSize)
         for i in range(32 - headerSize):
             self.assertEquals(CPyMarshal.ReadByte(zerosPtr), 0, "not zeroed")
@@ -467,7 +467,7 @@ class PyType_GenericAlloc_Test(TestCase):
         size = CPyMarshal.ReadIntField(result, PyVarObject, "ob_size")
         self.assertEquals(size, 3, "bad ob_size")
         
-        headerSize = Marshal.SizeOf(PyVarObject)
+        headerSize = Marshal.SizeOf(PyVarObject())
         zerosPtr = OffsetPtr(result, headerSize)
         for i in range(224 - headerSize):
             self.assertEquals(CPyMarshal.ReadByte(zerosPtr), 0, "not zeroed")

--- a/tests/utils/cpython.py
+++ b/tests/utils/cpython.py
@@ -147,7 +147,7 @@ def MakeTypePtr(mapper, params, allocator=None):
     fields.update(params)
     
     deallocs = []
-    typeSize = Marshal.SizeOf(PyTypeObject)
+    typeSize = Marshal.SizeOf(PyTypeObject())
     if allocator:
         # pretend this was constructed by a C extension, using the mapper's allocator
         # hence mapper should do the deallocation itself

--- a/tests/utils/memory.py
+++ b/tests/utils/memory.py
@@ -74,6 +74,7 @@ _others = {
 }
 def CreateTypes(mapper, readyTypes=True):
     blocks = []
+
     def create(name, size):
         block = Marshal.AllocHGlobal(size)
         if name == 'PyFile_Type':
@@ -83,7 +84,7 @@ def CreateTypes(mapper, readyTypes=True):
         blocks.append(block)
     
     for _type in _types:
-        create(_type, Marshal.SizeOf(PyTypeObject))
+        create(_type, Marshal.SizeOf(PyTypeObject()))
     for (_other, size) in _others.items():
         create(_other, size)
         


### PR DESCRIPTION
Call Marshal.SizeOf(Type()) so it is acting on an object.

Signed-off-by: Tim Orling TicoTimo@gmail.com
