### PR TITLE
ic_msvcr90 DllMain conflicting types

### DIFF
--- a/stub/ic_msvcr90.c
+++ b/stub/ic_msvcr90.c
@@ -98,11 +98,11 @@ void _Py_DeactivateActCtx(ULONG_PTR cookie)
 			printf("Python failed to de-activate the activation context\n");
 }
 
-BOOL	WINAPI	DllMain (HANDLE hInst,
-						ULONG ul_reason_for_call,
+BOOL	WINAPI	DllMain (HINSTANCE hInst,
+						DWORD dw_reason_for_call,
 						LPVOID lpReserved)
 {
-	switch (ul_reason_for_call)
+	switch (dw_reason_for_call)
 	{
 		case DLL_PROCESS_ATTACH:
 			// capture our activation context for use when loading extensions.


### PR DESCRIPTION
Fixes the following error:
    scons: Reading SConscript files ...
    scons: done reading SConscript files.
    scons: Building targets ...
    gcc -o stub\ic_msvcr90.o -c stub\ic_msvcr90.c
    stub\ic_msvcr90.c:101:13: error: conflicting types for 'DllMain'
     BOOL WINAPI DllMain (HANDLE hInst,
                 ^
    In file included from c:\mingw\include\windows.h:62:0,
                     from stub\ic_msvcr90.c:41:
    c:\mingw\include\winbase.h:1051:13: note: previous declaration of 'DllMain' was here
     BOOL WINAPI DllMain(HINSTANCE, DWORD, LPVOID);
                 ^
    scons: **\* [stub\ic_msvcr90.o] Error 1
    scons: building terminated because of errors.

Signed-off-by: Tim Orling TicoTimo@gmail.com
