### PR TITLE
make sure right overload of PtrToStructure is called

### DIFF
--- a/tests/functiontest.py
+++ b/tests/functiontest.py
@@ -4,7 +4,7 @@ from types import FunctionType
 from tests.utils.runtest import makesuite, run
 from tests.utils.testcase import TestCase, WithMapper
 
-from System import IntPtr
+from System import IntPtr, Type
 from System.Runtime.InteropServices import Marshal
 
 from Ironclad import CPyMarshal
@@ -15,6 +15,9 @@ attrs = (
     'func_name', 'func_dict', 'func_weakreflist', 'func_module'
 )
 
+# make sure this particular overload PtrToStructure(IntPtr, Type) is called
+PtrToStructure = Marshal.PtrToStructure.Overloads[IntPtr, Type]
+
 class FunctionTest(TestCase):
 
     @WithMapper
@@ -24,7 +27,7 @@ class FunctionTest(TestCase):
         def f(): pass
         fPtr = mapper.Store(f)
         
-        stored = Marshal.PtrToStructure(fPtr, PyFunctionObject)
+        stored = PtrToStructure(fPtr, PyFunctionObject)
         self.assertEquals(stored.ob_refcnt, 1)
         self.assertEquals(stored.ob_type, mapper.PyFunction_Type)
         

--- a/tests/listtest.py
+++ b/tests/listtest.py
@@ -7,13 +7,14 @@ from tests.utils.memory import CreateTypes, OffsetPtr
 from tests.utils.testcase import TestCase, WithMapper
 from tests.utils.typetestcase import TypeTestCase
 
-from System import IntPtr
+from System import IntPtr, Type
 from System.Runtime.InteropServices import Marshal
 
 from Ironclad import CPyMarshal, dgt_void_ptr, PythonMapper
 from Ironclad.Structs import PyObject, PyListObject, PyTypeObject
 
-
+# make sure this particular overload PtrToStructure(IntPtr, Type) is called
+PtrToStructure = Marshal.PtrToStructure.Overloads[IntPtr, Type]
 
 class PyList_Type_Test(TypeTestCase):
 
@@ -120,7 +121,7 @@ class ListFunctionsTest(TestCase):
         listPtr = mapper.PyList_New(0)
         self.assertEquals(allocs, [(listPtr, Marshal.SizeOf(PyListObject()))], "bad alloc")
 
-        listStruct = Marshal.PtrToStructure(listPtr, PyListObject)
+        listStruct = PtrToStructure(listPtr, PyListObject)
         self.assertEquals(listStruct.ob_refcnt, 1, "bad refcount")
         self.assertEquals(listStruct.ob_type, mapper.PyList_Type, "bad type")
         self.assertEquals(listStruct.ob_size, 0, "bad ob_size")
@@ -141,7 +142,7 @@ class ListFunctionsTest(TestCase):
         SIZE = 27
         listPtr = mapper.PyList_New(SIZE)
         
-        listStruct = Marshal.PtrToStructure(listPtr, PyListObject)
+        listStruct = PtrToStructure(listPtr, PyListObject)
         self.assertEquals(listStruct.ob_refcnt, 1, "bad refcount")
         self.assertEquals(listStruct.ob_type, mapper.PyList_Type, "bad type")
         self.assertEquals(listStruct.ob_size, SIZE, "bad ob_size")

--- a/tests/methodtest.py
+++ b/tests/methodtest.py
@@ -4,11 +4,13 @@ from types import MethodType
 from tests.utils.runtest import makesuite, run
 from tests.utils.testcase import TestCase, WithMapper
 
-from System import IntPtr
+from System import IntPtr, Type
 from System.Runtime.InteropServices import Marshal
 
 from Ironclad.Structs import PyMethodObject
 
+# make sure this particular overload PtrToStructure(IntPtr, Type) is called
+PtrToStructure = Marshal.PtrToStructure.Overloads[IntPtr, Type]
 
 class MethodTest(TestCase):
 
@@ -29,7 +31,7 @@ class MethodTest(TestCase):
         meth = MethodType('foo', 'bar', 'baz')
         methPtr = mapper.Store(meth)
         
-        stored = Marshal.PtrToStructure(methPtr, PyMethodObject)
+        stored = PtrToStructure(methPtr, PyMethodObject)
         self.assertEquals(stored.ob_refcnt, 1)
         self.assertEquals(stored.ob_type, mapper.PyMethod_Type)
         self.assertEquals(stored.im_weakreflist, IntPtr.Zero)

--- a/tests/pythonmapper_core_test.py
+++ b/tests/pythonmapper_core_test.py
@@ -9,7 +9,7 @@ from tests.utils.memory import CreateTypes
 from tests.utils.pythonmapper import MakeAndAddEmptyModule
 from tests.utils.testcase import TestCase, WithMapper
 
-from System import Int32, IntPtr, InvalidOperationException, NullReferenceException, WeakReference
+from System import Int32, IntPtr, InvalidOperationException, NullReferenceException, Type, WeakReference
 from System.Collections.Generic import Stack, List
 from System.Runtime.InteropServices import Marshal
 
@@ -19,6 +19,8 @@ from Ironclad import (
 )
 from Ironclad.Structs import PyObject, PyTypeObject
 
+# make sure this particular overload PtrToStructure(IntPtr, Type) is called
+PtrToStructure = Marshal.PtrToStructure.Overloads[IntPtr, Type]
 
 class PythonMapper_CreateDestroy_Test(TestCase):
     
@@ -624,7 +626,7 @@ class PythonMapper_NoneTest(TestCase):
     @WithMapper
     def testFillNone(self, mapper, _):
         nonePtr = mapper._Py_NoneStruct
-        noneStruct = Marshal.PtrToStructure(nonePtr, PyObject)
+        noneStruct = PtrToStructure(nonePtr, PyObject)
         self.assertEquals(noneStruct.ob_refcnt, 1, "bad refcount")
         self.assertEquals(noneStruct.ob_type, mapper.PyNone_Type, "unexpected type")
 
@@ -642,7 +644,7 @@ class PythonMapper_NotImplementedTest(TestCase):
     @WithMapper
     def testFillNotImplemented(self, mapper, _):
         niPtr = mapper._Py_NotImplementedStruct
-        niStruct = Marshal.PtrToStructure(niPtr, PyObject)
+        niStruct = PtrToStructure(niPtr, PyObject)
         self.assertEquals(niStruct.ob_refcnt, 1, "bad refcount")
         self.assertEquals(niStruct.ob_type, mapper.PyNotImplemented_Type, "unexpected type")
 

--- a/tests/stringtest.py
+++ b/tests/stringtest.py
@@ -6,11 +6,13 @@ from tests.utils.memory import OffsetPtr, CreateTypes
 from tests.utils.testcase import TestCase, WithMapper
 from tests.utils.typetestcase import TypeTestCase
 
-from System import Array, Byte, Char, IntPtr, UInt32
+from System import Array, Byte, Char, IntPtr, Type, UInt32
 from System.Runtime.InteropServices import Marshal
 from Ironclad import CPyMarshal, dgt_int_ptrintptr, dgt_int_ptrptr, dgt_ptr_ptrptr, PythonMapper
 from Ironclad.Structs import PyStringObject, PyTypeObject, PyBufferProcs, PySequenceMethods, Py_TPFLAGS
 
+# make sure this particular overload PtrToStructure(IntPtr, Type) is called
+PtrToStructure = Marshal.PtrToStructure.Overloads[IntPtr, Type]
 
 class PyString_TestCase(TestCase):
 
@@ -45,7 +47,7 @@ class PyString_TestCase(TestCase):
 
 
     def assertStringObjectHasLength(self, strPtr, length):
-        stringObject = Marshal.PtrToStructure(strPtr, PyStringObject)
+        stringObject = PtrToStructure(strPtr, PyStringObject)
         self.assertEquals(stringObject.ob_refcnt, 1, "unexpected refcount")
         self.assertEquals(stringObject.ob_size, length, "unexpected ob_size")
         self.assertEquals(stringObject.ob_shash, -1, "unexpected currently-useless-field")

--- a/tests/tupletest.py
+++ b/tests/tupletest.py
@@ -8,13 +8,14 @@ from tests.utils.memory import CreateTypes, OffsetPtr
 from tests.utils.testcase import TestCase, WithMapper
 from tests.utils.typetestcase import TypeTestCase
 
-from System import IntPtr
+from System import IntPtr, Type
 from System.Runtime.InteropServices import Marshal
 
 from Ironclad import CPyMarshal, dgt_void_ptr, PythonMapper
 from Ironclad.Structs import PyTupleObject, PyTypeObject
 
-
+# make sure this particular overload PtrToStructure(IntPtr, Type) is called
+PtrToStructure = Marshal.PtrToStructure.Overloads[IntPtr, Type]
 
 def MakeTuple(mapper, model):
     tuplePtr = mapper.PyTuple_New(len(model))
@@ -97,7 +98,7 @@ class TupleTest(TestCase):
         tuplePtr = mapper.PyTuple_New(length)
         expectedSize = Marshal.SizeOf(PyTupleObject()) + (CPyMarshal.PtrSize * (length - 1))
         self.assertEquals(allocs, [(tuplePtr, expectedSize)], "bad alloc")
-        tupleStruct = Marshal.PtrToStructure(tuplePtr, PyTupleObject)
+        tupleStruct = PtrToStructure(tuplePtr, PyTupleObject)
         self.assertEquals(tupleStruct.ob_refcnt, 1, "bad refcount")
         self.assertEquals(tupleStruct.ob_type, mapper.PyTuple_Type, "bad type")
         self.assertEquals(tupleStruct.ob_size, length, "bad size")
@@ -147,7 +148,7 @@ class TupleTest(TestCase):
         expectedSize = Marshal.SizeOf(PyTupleObject()) + (CPyMarshal.PtrSize * (99))
         self.assertEquals(allocs, [(newTuplePtr, expectedSize)])
         
-        tupleStruct = Marshal.PtrToStructure(newTuplePtr, PyTupleObject)
+        tupleStruct = PtrToStructure(newTuplePtr, PyTupleObject)
         self.assertEquals(tupleStruct.ob_refcnt, 1)
         self.assertEquals(tupleStruct.ob_type, mapper.PyTuple_Type)
         self.assertEquals(tupleStruct.ob_size, 100)


### PR DESCRIPTION
Universally apply pawel's patch for cpymarsheltest.py

Signed-off-by: Tim Orling TicoTimo@gmail.com
